### PR TITLE
Add parser test and CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Pytest
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+    - name: Run tests
+      run: pytest -v

--- a/tests/test_web_server_parsers.py
+++ b/tests/test_web_server_parsers.py
@@ -1,0 +1,12 @@
+import pytest
+from src.mcp_servers.web_server import _parse_gobuster_output
+
+
+def test_parse_gobuster_output(sample_gobuster_output):
+    results = _parse_gobuster_output(sample_gobuster_output)
+    assert results == [
+        {"path": "/admin", "status_code": 200, "size": 1234},
+        {"path": "/backup", "status_code": 403, "size": 278},
+        {"path": "/login", "status_code": 200, "size": 2156},
+        {"path": "/uploads", "status_code": 301, "size": 234},
+    ]


### PR DESCRIPTION
## Summary
- test gobuster output parser in web_server
- add minimal GitHub Actions workflow running pytest

## Testing
- `pytest tests/test_web_server_parsers.py -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684c9c4371b0832ba6d3522793b8b8c4