### PR TITLE
Add secret placeholders and validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,12 +35,12 @@ WORDLIST_ROCKYOU=/usr/share/wordlists/rockyou.txt
 MSF_RPC_HOST=localhost
 MSF_RPC_PORT=55553
 MSF_RPC_USER=msf
-MSF_RPC_PASS=password
+MSF_RPC_PASS=CHANGE_ME
 
 # Burp Suite Pro API (if available)
 BURP_API_HOST=localhost
 BURP_API_PORT=1337
-BURP_API_KEY=your_api_key_here
+BURP_API_KEY=CHANGE_ME
 
 # Report Configuration
 REPORT_OUTPUT_DIR=./reports
@@ -49,8 +49,8 @@ COMPANY_NAME=Your Company
 PENTESTER_NAME=Your Name
 
 # Security Configuration
-API_KEY_SECRET=your_secret_key_here
-JWT_SECRET=your_jwt_secret_here
+API_KEY_SECRET=CHANGE_ME
+JWT_SECRET=CHANGE_ME
 
 # Logging Configuration
 LOG_LEVEL=INFO
@@ -66,14 +66,14 @@ MAX_CONCURRENT_SCANS=5
 RATE_LIMIT_DELAY=1
 
 # OSINT Configuration
-SHODAN_API_KEY=your_shodan_api_key
-VIRUSTOTAL_API_KEY=your_virustotal_api_key
-CENSYS_API_ID=your_censys_api_id
-CENSYS_API_SECRET=your_censys_api_secret
+SHODAN_API_KEY=CHANGE_ME
+VIRUSTOTAL_API_KEY=CHANGE_ME
+CENSYS_API_ID=CHANGE_ME
+CENSYS_API_SECRET=CHANGE_ME
 
 # Social Engineering Configuration
 SET_CONFIG_PATH=/etc/setoolkit/set.config
-GOPHISH_API_KEY=your_gophish_api_key
+GOPHISH_API_KEY=CHANGE_ME
 GOPHISH_URL=https://localhost:3333
 
 # Development Configuration

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -13,38 +14,38 @@ MCP_SERVERS = {
     "data": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("DATA_SERVER_PORT", 5000)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
     },
     "network": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("NETWORK_SERVER_PORT", 5001)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
     },
     "web": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("WEB_SERVER_PORT", 5002)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
     },
     "vulnerability": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("VULN_SERVER_PORT", 5003)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
     },
     "forensic": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("FORENSIC_SERVER_PORT", 5004)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
     },
     "social": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("SOCIAL_SERVER_PORT", 5005)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
     },
     "report": {
         "host": os.getenv("DATA_SERVER_HOST", "localhost"),
         "port": int(os.getenv("REPORT_SERVER_PORT", 5006)),
-        "transport": os.getenv("MCP_TRANSPORT", "http")
-    }
+        "transport": os.getenv("MCP_TRANSPORT", "http"),
+    },
 }
 
 # LLM configuration
@@ -52,7 +53,7 @@ LLM_CONFIG = {
     "model": os.getenv("LLM_MODEL", "llama3.2"),
     "host": os.getenv("LLM_HOST", "localhost"),
     "port": int(os.getenv("LLM_PORT", 11434)),
-    "base_url": f"http://{os.getenv('LLM_HOST', 'localhost')}:{os.getenv('LLM_PORT', 11434)}"
+    "base_url": f"http://{os.getenv('LLM_HOST', 'localhost')}:{os.getenv('LLM_PORT', 11434)}",
 }
 
 # Kali Tools Configuration
@@ -78,14 +79,14 @@ METASPLOIT_CONFIG = {
     "host": os.getenv("MSF_RPC_HOST", "localhost"),
     "port": int(os.getenv("MSF_RPC_PORT", 55553)),
     "user": os.getenv("MSF_RPC_USER", "msf"),
-    "password": os.getenv("MSF_RPC_PASS", "password"),
+    "password": os.getenv("MSF_RPC_PASS", "CHANGE_ME"),
 }
 
 # Burp Suite Configuration
 BURP_CONFIG = {
     "host": os.getenv("BURP_API_HOST", "localhost"),
     "port": int(os.getenv("BURP_API_PORT", 1337)),
-    "api_key": os.getenv("BURP_API_KEY", ""),
+    "api_key": os.getenv("BURP_API_KEY", "CHANGE_ME"),
 }
 
 # Report Configuration
@@ -98,8 +99,8 @@ REPORT_CONFIG = {
 
 # Security Configuration
 SECURITY_CONFIG = {
-    "api_key_secret": os.getenv("API_KEY_SECRET", "your_secret_key_here"),
-    "jwt_secret": os.getenv("JWT_SECRET", "your_jwt_secret_here"),
+    "api_key_secret": os.getenv("API_KEY_SECRET", "CHANGE_ME"),
+    "jwt_secret": os.getenv("JWT_SECRET", "CHANGE_ME"),
 }
 
 # Logging Configuration
@@ -123,16 +124,16 @@ NETWORK_CONFIG = {
 
 # OSINT Configuration
 OSINT_CONFIG = {
-    "shodan_api_key": os.getenv("SHODAN_API_KEY", ""),
-    "virustotal_api_key": os.getenv("VIRUSTOTAL_API_KEY", ""),
-    "censys_api_id": os.getenv("CENSYS_API_ID", ""),
-    "censys_api_secret": os.getenv("CENSYS_API_SECRET", ""),
+    "shodan_api_key": os.getenv("SHODAN_API_KEY", "CHANGE_ME"),
+    "virustotal_api_key": os.getenv("VIRUSTOTAL_API_KEY", "CHANGE_ME"),
+    "censys_api_id": os.getenv("CENSYS_API_ID", "CHANGE_ME"),
+    "censys_api_secret": os.getenv("CENSYS_API_SECRET", "CHANGE_ME"),
 }
 
 # Social Engineering Configuration
 SOCIAL_CONFIG = {
     "set_config_path": Path(os.getenv("SET_CONFIG_PATH", "/etc/setoolkit/set.config")),
-    "gophish_api_key": os.getenv("GOPHISH_API_KEY", ""),
+    "gophish_api_key": os.getenv("GOPHISH_API_KEY", "CHANGE_ME"),
     "gophish_url": os.getenv("GOPHISH_URL", "https://localhost:3333"),
 }
 
@@ -141,3 +142,26 @@ DEVELOPMENT_CONFIG = {
     "debug": os.getenv("DEBUG", "false").lower() == "true",
     "development_mode": os.getenv("DEVELOPMENT_MODE", "false").lower() == "true",
 }
+
+# Fail fast if secrets are not properly configured
+PLACEHOLDER_VALUE = "CHANGE_ME"
+
+if os.getenv("TESTING") != "true":
+    secret_checks = {
+        "MSF_RPC_PASS": METASPLOIT_CONFIG["password"],
+        "API_KEY_SECRET": SECURITY_CONFIG["api_key_secret"],
+        "JWT_SECRET": SECURITY_CONFIG["jwt_secret"],
+        "BURP_API_KEY": BURP_CONFIG["api_key"],
+        "SHODAN_API_KEY": OSINT_CONFIG["shodan_api_key"],
+        "VIRUSTOTAL_API_KEY": OSINT_CONFIG["virustotal_api_key"],
+        "CENSYS_API_ID": OSINT_CONFIG["censys_api_id"],
+        "CENSYS_API_SECRET": OSINT_CONFIG["censys_api_secret"],
+        "GOPHISH_API_KEY": SOCIAL_CONFIG["gophish_api_key"],
+    }
+
+    for name, value in secret_checks.items():
+        if value == PLACEHOLDER_VALUE:
+            raise ValueError(
+                f"Environment variable {name} is using the placeholder value. "
+                "Update your .env configuration."
+            )


### PR DESCRIPTION
## Summary
- update example environment to use `CHANGE_ME` placeholders for secrets
- set default secret values to `CHANGE_ME`
- ensure settings throw an error when secrets are left as placeholders

## Testing
- `black -q src/config/settings.py`
- `isort src/config/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684ca4835938832b88a912698c63979d