### PR TITLE
Add parser tests with local mocks

### DIFF
--- a/tests/test_network_server_parsers.py
+++ b/tests/test_network_server_parsers.py
@@ -1,0 +1,21 @@
+import pytest
+from src.mcp_servers.network_server import _parse_nmap_xml, _parse_discovery_output
+
+
+def test_parse_nmap_xml(sample_nmap_xml):
+    results = _parse_nmap_xml(sample_nmap_xml)
+    assert results["status"] == "completed"
+    assert "127.0.0.1" in results["hosts"]
+    host = results["hosts"]["127.0.0.1"]
+    assert host["status"] == "up"
+    assert any(p["port"] == 22 for p in host["ports"])
+    assert host["os"]["name"] == "Linux"
+
+
+def test_parse_discovery_output(sample_discovery_output):
+    results = _parse_discovery_output(sample_discovery_output)
+    assert results == [
+        {"ip": "192.168.1.10", "hostname": "host1", "status": "up"},
+        {"ip": "192.168.1.11", "hostname": "192.168.1.11", "status": "up"},
+    ]
+

--- a/tests/test_web_server_parsers.py
+++ b/tests/test_web_server_parsers.py
@@ -1,5 +1,10 @@
 import pytest
-from src.mcp_servers.web_server import _parse_gobuster_output
+from src.mcp_servers.web_server import (
+    _parse_gobuster_output,
+    _parse_nikto_output,
+    _parse_sqlmap_output,
+    _parse_whatweb_output,
+)
 
 
 def test_parse_gobuster_output(sample_gobuster_output):
@@ -9,4 +14,34 @@ def test_parse_gobuster_output(sample_gobuster_output):
         {"path": "/backup", "status_code": 403, "size": 278},
         {"path": "/login", "status_code": 200, "size": 2156},
         {"path": "/uploads", "status_code": 301, "size": 234},
+    ]
+
+
+def test_parse_nikto_output(sample_nikto_output):
+    results = _parse_nikto_output(sample_nikto_output)
+    assert results == [
+        {
+            "id": "1",
+            "msg": "Possible SQL injection",
+            "uri": "/index.php",
+            "method": "GET",
+            "OSVDB": "12345",
+            "severity": "high",
+        }
+    ]
+
+
+def test_parse_sqlmap_output(sample_sqlmap_output):
+    results = _parse_sqlmap_output(sample_sqlmap_output)
+    assert {
+        "type": "Boolean-based blind SQL injection",
+        "severity": "high",
+        "technique": "boolean",
+    } in results
+
+
+def test_parse_whatweb_output(sample_whatweb_output):
+    results = _parse_whatweb_output(sample_whatweb_output)
+    assert results == [
+        {"name": "Apache", "confidence": "Medium", "version": "2.4.52", "details": "Apache httpd"}
     ]


### PR DESCRIPTION
## Summary
- add fixtures for sample tool outputs
- provide dummy modules in `conftest.py` for missing dependencies
- add parser tests for network and web servers

## Testing
- `PYTHONPATH=$PWD pytest -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_684caa4c0d20832bbdce988bf3a3b8eb