### PR TITLE
Fix coverage config placement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ exclude_lines = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod"
 ]
+fail_under = 90
 
 [tool.black]
 line-length = 88
@@ -183,5 +184,3 @@ Repository = "https://github.com/Huleinpylo/kali-agents-mcp.git"
 Issues = "https://github.com/Huleinpylo/kali-agents-mcp/issues"
 Changelog = "https://github.com/Huleinpylo/kali-agents-mcp/blob/main/CHANGELOG.md"
 Security = "https://github.com/Huleinpylo/kali-agents-mcp/security/policy"
-
-fail_under = 90


### PR DESCRIPTION
## Summary
- ensure `fail_under` lives inside `[tool.coverage.report]`
- remove stray duplicate setting

## Testing
- `PYTHONPATH=$PWD pytest --override-ini addopts='' -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850804ef788832b83d5e117482b6fb0