### PR TITLE
Fix CLI entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ docs = [
 
 
 [project.scripts]
-kali-agents = "src.cli.main:app"
+kali-agents = "src.cli.main:cli"
 
 
 # Add OpenSSF Badge support


### PR DESCRIPTION
## Summary
- point `kali-agents` script at the Click `cli` group

## Testing
- `pip install -e .` *(fails: Could not install build dependencies)*
- `python -m src.cli.main --help` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6850804d7b74832b8c6de1504cc83a07