### PR TITLE
Add unit tests for supervisor and parsing

### DIFF
--- a/tests/test_supervisor_agent.py
+++ b/tests/test_supervisor_agent.py
@@ -1,0 +1,75 @@
+import sys
+import types
+import pytest
+
+# Provide a minimal fastmcp stub so SupervisorAgent can be imported without the
+# real dependency.
+fastmcp_stub = types.ModuleType("fastmcp")
+fastmcp_stub.Client = object  # type: ignore
+
+class DummyMCP:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def tool(self, func):
+        return func
+
+    def run(self):
+        pass
+
+fastmcp_stub.FastMCP = DummyMCP  # type: ignore
+fastmcp_stub.Context = object  # type: ignore
+sys.modules.setdefault("fastmcp", fastmcp_stub)
+
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.array = lambda *a, **k: None  # minimal stub
+sys.modules.setdefault("numpy", numpy_stub)
+
+from src.agents.supervisor import SupervisorAgent
+
+@pytest.mark.asyncio
+async def test_create_network_plan():
+    sup = SupervisorAgent(agent_id="sup1")
+    task = await sup._analyze_and_create_task("network scan", {"target": "example.com"})
+    plan = await sup._create_execution_plan(task)
+    assert plan.task_id == task.id
+    assert plan.assigned_agents == ["network_agent"]
+    assert any(step["name"] == "Network Discovery" for step in plan.steps)
+
+@pytest.mark.asyncio
+async def test_extract_findings():
+    sup = SupervisorAgent(agent_id="sup2")
+    step_results = [
+        {
+            "tool": "nmap_scan",
+            "result": {
+                "hosts": {
+                    "example.com": {
+                        "status": "up",
+                        "ports": [
+                            {"port": 22, "protocol": "tcp", "service": "ssh", "state": "open"}
+                        ]
+                    }
+                }
+            },
+        },
+        {
+            "tool": "nikto_scan",
+            "result": {
+                "vulnerabilities": [
+                    {"id": "OSVDB-1", "msg": "Server header", "severity": "info"}
+                ]
+            },
+        },
+        {
+            "tool": "gobuster_directory",
+            "result": {
+                "discovered_paths": [
+                    {"path": "/admin", "status_code": 200, "size": 123}
+                ]
+            },
+        },
+    ]
+    findings = sup._extract_findings_from_results(step_results)
+    types = {f["type"] for f in findings}
+    assert {"open_port", "web_vulnerability", "interesting_path"} <= types

--- a/tests/test_web_server_additional.py
+++ b/tests/test_web_server_additional.py
@@ -1,0 +1,49 @@
+import sys
+import types
+import pytest
+
+# Stub fastmcp so that web_server can be imported without the real package.
+fastmcp_stub = types.ModuleType("fastmcp")
+class DummyMCP:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def tool(self, func):
+        return func
+
+    def run(self):
+        pass
+
+fastmcp_stub.FastMCP = DummyMCP  # type: ignore
+fastmcp_stub.Context = object  # type: ignore
+sys.modules.setdefault("fastmcp", fastmcp_stub)
+
+numpy_stub = types.ModuleType("numpy")
+sys.modules.setdefault("numpy", numpy_stub)
+
+# The server imports dotenv for configuration loading. Provide a stub to avoid
+# missing dependency errors during import.
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+from src.mcp_servers.web_server import _parse_nikto_text_output, _classify_nikto_severity
+
+
+def test_parse_nikto_text_output():
+    text = """
++ OSVDB-3092: SQL injection risk found
++ OSVDB-4123: header disclosure
+"""
+    vulns = _parse_nikto_text_output(text)
+    assert vulns == [
+        {"id": "NIKTO-TEXT", "msg": "OSVDB-3092: SQL injection risk found", "severity": "high"},
+        {"id": "NIKTO-TEXT", "msg": "OSVDB-4123: header disclosure", "severity": "medium"},
+    ]
+
+
+def test_classify_nikto_severity():
+    assert _classify_nikto_severity("Possible SQL injection") == "high"
+    assert _classify_nikto_severity("password disclosure") == "medium"
+    assert _classify_nikto_severity("Server header exposed") == "medium"
+    assert _classify_nikto_severity("other info") == "info"


### PR DESCRIPTION
## Summary
- add async tests for supervisor plan building and finding extraction
- add parsing tests for nikto text output and severity helper

## Testing
- `PYTHONPATH=$PWD pytest tests/test_supervisor_agent.py tests/test_web_server_additional.py -q -o addopts=''`
- `PYTHONPATH=$PWD pytest -q -o addopts=''` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68508055c018832b8dbb5c3d4924c6da