### PR TITLE
Potential fix for code scanning alert no. 32: Redundant comparison

### DIFF
--- a/src/models/ml_algorithms.py
+++ b/src/models/ml_algorithms.py
@@ -66,7 +66,7 @@ class FuzzyLogicEngine(AdaptationAlgorithm):
         a, b, c = params
         if x <= a or x >= c:
             return 0.0
-        elif a < x <= b:
+        elif x <= b:
             return (x - a) / (b - a)
         else:
             return (c - x) / (c - b)


### PR DESCRIPTION
Potential fix for [https://github.com/Huleinpylo/kali-agents-mcp/security/code-scanning/32](https://github.com/Huleinpylo/kali-agents-mcp/security/code-scanning/32)

To fix the redundant comparison, we need to simplify the logic in the `triangular_membership` method. Specifically, the condition `a < x <= b` on line 69 should be replaced with `x <= b`, as `x > a` is already guaranteed to be true when execution reaches this point. This change will eliminate the redundancy while preserving the intended functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
